### PR TITLE
From exe start feature and not accurate process name.

### DIFF
--- a/WinAppDriver/ApplicationProcess.cs
+++ b/WinAppDriver/ApplicationProcess.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Runtime.InteropServices;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace WinAppDriver
@@ -13,31 +15,25 @@ namespace WinAppDriver
     {
         public static Process StartProcessFromPath(string path, int timeout = 3000)
         {
-            // if existed the process with such path to the executable, then return it
-            var process = Process.GetProcesses()
-                .Where(x => x.MainModule.FileName == path).FirstOrDefault();
 
-            if (process == null)
+            var process = Process.Start(path);
+            process.WaitForInputIdle(timeout);
+            process.Refresh();
+            if (process.MainWindowHandle.ToInt32() == 0)
             {
-                process = Process.Start(path);
-                process.WaitForInputIdle(timeout);
-                process.Refresh();
-                if (process.MainWindowHandle.ToInt32() == 0)
+                int time = 0;
+                while (!process.HasExited)
                 {
-                    int time = 0;
-                    while (!process.HasExited)
+                    process.Refresh();
+                    if (process.MainWindowHandle.ToInt32() != 0)
                     {
-                        process.Refresh();
-                        if (process.MainWindowHandle.ToInt32() != 0)
-                        {
-                            return process;
-                        }
-                        Thread.Sleep(50);
-                        time += 50;
-                        if (time > timeout)
-                        {
-                            throw new TimeoutException("Process starting timeout expired.");
-                        }
+                        return process;
+                    }
+                    Thread.Sleep(50);
+                    time += 50;
+                    if (time > timeout)
+                    {
+                        throw new TimeoutException("Process starting timeout expired.");
                     }
                 }
             }

--- a/WinAppDriver/ApplicationProcess.cs
+++ b/WinAppDriver/ApplicationProcess.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Diagnostics;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WinAppDriver
+{
+    class ApplicationProcess
+    {
+        public static Process StartProcessFromPath(string path, int timeout = 3000)
+        {
+            // if existed the process with such path to the executable, then return it
+            var process = Process.GetProcesses()
+                .Where(x => x.MainModule.FileName == path).FirstOrDefault();
+
+            if (process == null)
+            {
+                process = Process.Start(path);
+                process.WaitForInputIdle(timeout);
+                process.Refresh();
+                if (process.MainWindowHandle.ToInt32() == 0)
+                {
+                    int time = 0;
+                    while (!process.HasExited)
+                    {
+                        process.Refresh();
+                        if (process.MainWindowHandle.ToInt32() != 0)
+                        {
+                            return process;
+                        }
+                        Thread.Sleep(50);
+                        time += 50;
+                        if (time > timeout)
+                        {
+                            throw new TimeoutException("Process starting timeout expired.");
+                        }
+                    }
+                }
+            }
+
+            return process;
+        }
+    }
+}

--- a/WinAppDriver/CommandHandlers/NewSessionCommandHandler.cs
+++ b/WinAppDriver/CommandHandlers/NewSessionCommandHandler.cs
@@ -79,7 +79,7 @@ namespace WinAppDriver.Server.CommandHandlers
             }
 
             // check does mode is process and capabilities contain exePath simultaneounsy
-            if (mode?.ToString() == "executable" & !desiredCapabilities.TryGetValue("processName", out var exePath))
+            if (mode?.ToString() == "executable" & !desiredCapabilities.TryGetValue("exePath", out var exePath))
             {
                 return Response.CreateMissingParametersResponse("exePath");
             }

--- a/WinAppDriver/CommandHandlers/NewSessionCommandHandler.cs
+++ b/WinAppDriver/CommandHandlers/NewSessionCommandHandler.cs
@@ -73,13 +73,13 @@ namespace WinAppDriver.Server.CommandHandlers
             }
 
             // check does mode is process and capabilities contain processName simultaneounsy
-            if (mode?.ToString() == "process" & !desiredCapabilities.TryGetValue("processName", out var processName))
+            if (mode?.ToString() == "attach" & !desiredCapabilities.TryGetValue("processName", out var processName))
             {
                 return Response.CreateMissingParametersResponse("processName");
             }
 
             // check does mode is process and capabilities contain exePath simultaneounsy
-            if (mode?.ToString() == "executable" & !desiredCapabilities.TryGetValue("exePath", out var exePath))
+            if (mode?.ToString() == "start" & !desiredCapabilities.TryGetValue("exePath", out var exePath))
             {
                 return Response.CreateMissingParametersResponse("exePath");
             }
@@ -110,7 +110,7 @@ namespace WinAppDriver.Server.CommandHandlers
                 process = ApplicationProcess.StartProcessFromPath(exePath.ToString());
                 if (process == null)
                 {
-                    return Response.CreateErrorResponse(-1, "Can't start process.");
+                    return Response.CreateErrorResponse(-1, "Cannot start process.");
                 }
             }
 

--- a/WinAppDriver/WinAppDriver.csproj
+++ b/WinAppDriver/WinAppDriver.csproj
@@ -80,6 +80,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationProcess.cs" />
     <Compile Include="Behaviors\UnexpectedAlertBehavior2.cs" />
     <Compile Include="Behaviors\UnexpectedAlertBehavior.cs" />
     <Compile Include="Bootstrapper.cs" />


### PR DESCRIPTION
Have changed the code in creating a session method. Now available create a session from the path to exe. Also because you don't always know exactly what is process name, add support of not accurate process names.

Please give me feedback if you can, I'm not a very good C# programmer. But want to be better :)

p.s. Sorry for bad name of the last commit.