### PR TITLE
Add support for appWorkingDir capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Following capabilities are supported:
   - `processId` - id of the process to attach to
   - `processName` - name of the process to attach to
   - `exePath` or `app` - path to the executable to start the process (arguments cannot be provided at the moment)
+  - `appWorkingDir` - set the working directory of the new process
   - `mainWindowTitle` - regular expression to help the WinAppDriver narrow down the process to attach to 
 
 ### Creating session
@@ -203,6 +204,8 @@ public static RemoteWebDriver CreateSessionByStartingTheApplication()
   desktopCapabilities.SetCapability("app", "<name of the program to start>");  
   // or "exePath" desktopCapabilities.SetCapability("exePath", "<path to the executable to start the process>");  
   // following capabilities should be provided for UWP applications like Calculator or Clocks & Alarms 
+  // optional - to set the working directory
+  desktopCapabilities.SetCapability("appWorkingDir", "<path to run the process in>"); 
   // optional - to identify the process
   desktopCapabilities.SetCapability("processName", "<name of the process>"); 
   // optional - to identify the main window

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Why another driver, when there already is https://github.com/Microsoft/WinAppDri
 
 ## Installation
 Currently, there is no installer. Clone the repository and build the executable from the sources.
+Use the executable found under `WinAppDriver.Server\bin\Debug\WinAppDriver.Server.exe`
+
+## External Requirements
+Some features use the [AutoIt](https://www.autoitscript.com/site/autoit/downloads/) automation DLL.
+Acquire the Zip release and copy `AutoItX3_x64.dll` to the WinAppDriver executable directory.
 
 ## Selenium
 ### Client driver version

--- a/WinAppDriver/ApplicationProcess.cs
+++ b/WinAppDriver/ApplicationProcess.cs
@@ -12,7 +12,7 @@ namespace WinAppDriver
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-        public static Process StartProcessFromPath(string path, CancellationToken cancellationToken, string processName = null, string mainWindowTitlePattern = null)
+        public static Process StartProcessFromPath(string path, CancellationToken cancellationToken, string processName = null, string mainWindowTitlePattern = null, string workingDirectory = null)
         {
             Logger.Info("Starting process from path " + path);
 
@@ -23,6 +23,7 @@ namespace WinAppDriver
             };
 
             processName = processName?.Trim();
+            startInfo.WorkingDirectory = workingDirectory;
 
             var process = Process.Start(startInfo);
 

--- a/WinAppDriver/CommandHandlers/NewSessionCommandHandler.cs
+++ b/WinAppDriver/CommandHandlers/NewSessionCommandHandler.cs
@@ -97,8 +97,9 @@ namespace WinAppDriver.Server.CommandHandlers
                     }
 
                     desiredCapabilities.TryGetParameterValue<string>("processName", out var processName);
+                    desiredCapabilities.TryGetParameterValue<string>("appWorkingDir", out var workingDirectory);
 
-                    process = ApplicationProcess.StartProcessFromPath(exePath.ToString(), cancellationToken, processName, mainWindowTitle);
+                    process = ApplicationProcess.StartProcessFromPath(exePath.ToString(), cancellationToken, processName, mainWindowTitle, workingDirectory);
                     if (process == null)
                     {
                         return Response.CreateErrorResponse(-1, "Cannot start process.");


### PR DESCRIPTION
I have an application that uses a plugin system whose directory is relative to the location of the executable. This patch allows the tester to specify the working directory instead of taking the default working directory.
Documentation related to this feature has been written.